### PR TITLE
Hide option to upload profile image if no page name is set

### DIFF
--- a/resources/views/studio/page.blade.php
+++ b/resources/views/studio/page.blade.php
@@ -6,11 +6,14 @@
 
         <form action="{{ route('editPage') }}" enctype="multipart/form-data" method="post">
           @csrf
+          @foreach($pages as $page)
+          {{-- Hides option to upload profile image if no page name is set --}}
+          @if($page->littlelink_name != '')
           <div class="form-group col-lg-8">
             <label>Logo</label>
             <input type="file" class="form-control-file" name="image">
           </div>
-          @foreach($pages as $page)
+          @endif
           <div class="form-group col-lg-8">
             <label>Littlelink name</label>
             <input type="text" class="form-control" name="pageName" value="{{ $page->littlelink_name ?? '' }}">


### PR DESCRIPTION
**Quick and easy fix.**

Hides option to upload profile image if no page name is set on /studio/page. 

Without this, users without a page name, would be able to upload a profile image that then gets used as the default profile image for all users without a page name.

![chrome_AmxOOz8Xgg](https://user-images.githubusercontent.com/60265788/168340263-f3ebdde7-6f24-4996-a214-f184442e941c.png)
![chrome_fvau1zvc75](https://user-images.githubusercontent.com/60265788/168340268-52be0670-bb28-4572-8abc-e1e67b76e36b.png)

It's not the best solution, but an easy one.
